### PR TITLE
Modified plugin to have the option for "live recognition"

### DIFF
--- a/Plugins/SpeechRecognition/Source/SpeechRecognition/Private/SpeechRecognitionWorker.cpp
+++ b/Plugins/SpeechRecognition/Source/SpeechRecognition/Private/SpeechRecognitionWorker.cpp
@@ -1,4 +1,5 @@
 ﻿#include "SpeechRecognition.h"
+#include "SpeechRecognitionActor.h"
 #include "SpeechRecognitionWorker.h"
 
 //General Log
@@ -39,31 +40,57 @@ void FSpeechRecognitionWorker::ShutDown() {
 	delete Thread;
 }
 
-void FSpeechRecognitionWorker::SetLanguage(ESpeechRecognitionLanguage language) {
-
-	// set Content Path
-	FString contentPath = FPaths::ConvertRelativePathToFull(FPaths::GameContentDir());
-	contentPath_str = std::string(TCHAR_TO_UTF8(*contentPath));
-
-	// language model and dictionary paths
-	switch (language) {
-	case ESpeechRecognitionLanguage::VE_English:
-		langStr = "en";
-		break;
-	case ESpeechRecognitionLanguage::VE_Chinese:
-		langStr = "zn";
-		break;
-	case ESpeechRecognitionLanguage::VE_French:
-		langStr = "fr";
-		break;
-	default:
-		langStr = "en";
-		break;
-	}
-
+bool FSpeechRecognitionWorker::EnablePhoneticMode()
+{
+	detectionMode = ESpeechRecognitionMode::VE_PHONETIC;
+	return true;
 }
 
+bool FSpeechRecognitionWorker::EnableGrammarMode(FString grammarName)
+{
+	const char* name = TCHAR_TO_ANSI(*grammarName);
+	std::string grammarFile = contentPath_str + "model/" + langStr + "/grammars/" + name + ".gram";
+	
+	// Init config and set default params
+	InitConfig();
+	cmd_ln_set_str_r(config, "-jsgf", grammarFile.c_str());
+	cmd_ln_set_float_r(config, "-beam", 1e-20);
+	cmd_ln_set_float_r(config, "-wbeam", 1e-30);
+	cmd_ln_set_float_r(config, "-pbeam", 1e-20);
+
+	initRequired = true;
+	detectionMode = ESpeechRecognitionMode::VE_GRAMMAR;
+	return true;
+}
+
+bool FSpeechRecognitionWorker::EnableKeywordMode(TArray<FRecognitionPhrase> wordList)
+{
+	// Init config and set default params
+	InitConfig();
+	cmd_ln_set_boolean_r(config, "-bestpath", true);
+
+	AddWords(wordList);
+
+	std::ifstream file(dictionaryPath);
+	std::string currentLine;
+
+	// load dictionary
+	dictionary.clear();
+	while (file.good())
+	{
+		std::getline(file, currentLine);
+		std::string word = currentLine.substr(0, currentLine.find(" "));
+		dictionary.insert(word);
+	}
+
+	initRequired = true;
+	detectionMode = ESpeechRecognitionMode::VE_KEYWORD;
+	return true;
+}
+
+
 void FSpeechRecognitionWorker::AddWords(TArray<FRecognitionPhrase> keywords) {
+	this->keywords.clear();
 	for (auto It = keywords.CreateConstIterator(); It; ++It)
 	{
 		FRecognitionPhrase word = *It;
@@ -116,127 +143,155 @@ void FSpeechRecognitionWorker::AddWords(TArray<FRecognitionPhrase> keywords) {
 	}
 }
 
-bool FSpeechRecognitionWorker::Init() {
+void FSpeechRecognitionWorker::SetLanguage(ESpeechRecognitionLanguage language) {
 
-	std::string logPath = contentPath_str + "log/";
-	std::string modelPath = contentPath_str + "model/" + langStr + "/" + langStr;
-	std::string languageModel = contentPath_str + "model/" + langStr + "/" + langStr + ".lm";
-	std::string dictionaryPath = contentPath_str + "model/" + langStr + "/" + langStr + ".dict";
+	// set Content Path
+	FString contentPath = FPaths::ConvertRelativePathToFull(FPaths::GameContentDir());
+	contentPath_str = std::string(TCHAR_TO_UTF8(*contentPath));
 
-	std::ifstream file(dictionaryPath);
-	std::string currentLine;
-
-	// load dictionary
-	dictionary.clear();
-
-	while (file.good())
-	{
-		std::getline(file, currentLine);
-		std::string word = currentLine.substr(0, currentLine.find(" "));
-		dictionary.insert(word);
+	// language model and dictionary paths
+	switch (language) {
+	case ESpeechRecognitionLanguage::VE_English:
+		langStr = "en";
+		break;
+	case ESpeechRecognitionLanguage::VE_Chinese:
+		langStr = "zn";
+		break;
+	case ESpeechRecognitionLanguage::VE_French:
+		langStr = "fr";
+		break;
+	default:
+		langStr = "en";
+		break;
 	}
 
-	// Start Sphinx
+}
+
+
+void FSpeechRecognitionWorker::InitConfig() {
+	logPath = contentPath_str + "log/";
+	modelPath = contentPath_str + "model/" + langStr + "/" + langStr;
+	languageModel = contentPath_str + "model/" + langStr + "/" + langStr + ".lm";
+	dictionaryPath = contentPath_str + "model/" + langStr + "/" + langStr + ".dict";
+	
+	if (ps != NULL) {
+		cmd_ln_free_r(config);
+	}
+
 	config = cmd_ln_init(NULL, ps_args(), 1,
 		"-hmm", modelPath.c_str(),
 		"-dict", dictionaryPath.c_str(),
-		"-bestpath", "yes",
+		"-agc", "max",
 		NULL);
-
-	ps = ps_init(config);
-
-	if (!Manager | !ps) {
-		ClientMessage(FString(TEXT("Speech Recognition Thread failed to start")));
-		initSuccess = false;
-		return false;
-	}
-
-	// attempt to open the default recording device
-	if ((ad = ad_open_dev(cmd_ln_str_r(config, "-adcdev"),
-		(int)cmd_ln_float32_r(config,
-			"-samprate"))) == NULL) {
-		ClientMessage(FString(TEXT("Failed to open audio device")));
-		initSuccess = false;
-		return initSuccess;
-	}
-
-	utt_started = 0;
-	return true;
 }
 
 uint32 FSpeechRecognitionWorker::Run() {
 
-
-	// attempt to open the default recording device
-	if ((ad = ad_open_dev(cmd_ln_str_r(config, "-adcdev"),
-		(int)cmd_ln_float32_r(config,
-			"-samprate"))) == NULL) {
-		ClientMessage(FString(TEXT("Failed to open audio device")));
-		return 1;
-	}
-	if (ad_start_rec(ad) < 0) {
-		ClientMessage(FString(TEXT("Failed to start recording")));
-		return 2;
-	}
-
-	// set key-phrases
-	map<string, char*>::iterator it;
-	char** phrases = (char**)malloc(keywords.size() * sizeof(char*));
-	int32* tollerences;
-	tollerences = (int32*)malloc(keywords.size() * sizeof(int32));
-	int i = 0;
-
-	for (it = keywords.begin(); it != keywords.end(); ++it) {
-
-		// check if the word is in the dictionary. If missing, omit the phrase, and log
-		vector<string> splitString = Split(it->first);
-		vector<string>::iterator v_It;
-
-		bool skip = false;
-		for (v_It = splitString.begin(); v_It != splitString.end(); ++v_It) {
-			if (dictionary.find(*v_It) == dictionary.end()) {
-				skip = true;
-			}
-		}
-
-		if (skip)
-		{
-			std::string Strtxt = "The phrase '" + it->first + "' can not be added, as it contains words that are not in the dictionary.";
-			const char* txt = Strtxt.c_str();
-			// "' contains words that do not exist in the dictionary. Ignoring phrase.";
-			FString msg = FString(UTF8_TO_TCHAR(txt));
-			UE_LOG(SpeechRecognitionPlugin, Log, TEXT("SKIPPED PHRASE: %s "), *msg);
-			continue;
-		}
-
-		// keyword
-		char* str;
-		str = (char *)malloc(it->first.size() + 1);
-		memcpy(str, it->first.c_str(), it->first.size() + 1);
-		phrases[i] = str;
-
-		//tollerence
-		int32 tollerenceInt = (int32)logmath_log(ps_get_logmath(ps), atof(it->second)) >> SENSCR_SHIFT;
-		tollerences[i] = tollerenceInt;
-		i++;
-	}
-
-
-
-
-	int phraseCnt = i;
-	const char** const_copy = (const char**)phrases;
-	ps_set_keyphrase(ps, "keyphrase_search", const_copy, tollerences, phraseCnt);
-	ps_set_search(ps, "keyphrase_search");
-
-	if (ps_start_utt(ps) < 0) {
-		ClientMessage(FString(TEXT("Failed to start utterance")));
-		return 3;
-	}
-	
+	bool initComplete = false;
 	uint8 prev_in_speech = 0;
 
+	float elapsed_time_ms;
+	clock_t prev_time = clock();
+
 	while (StopTaskCounter.GetValue() == 0) {
+		// loop until we have initialised 
+		if (initRequired) {
+
+			/*
+			if (ps != NULL) {
+				ps_free(ps);				
+			}
+			*/
+
+			ps_default_search_args(config);
+			ps = ps_init(config);
+			
+			if (!Manager | !ps) {
+				ClientMessage(FString(TEXT("Speech Recognition Thread failed to start")));
+				return 1;
+			}
+
+			if (detectionMode == ESpeechRecognitionMode::VE_KEYWORD) {
+
+				// set key-phrases
+				map<string, char*>::iterator it;
+				char** phrases = (char**)malloc(keywords.size() * sizeof(char*));
+				int32* tollerences;
+				tollerences = (int32*)malloc(keywords.size() * sizeof(int32));
+				int i = 0;
+
+				for (it = keywords.begin(); it != keywords.end(); ++it) {
+
+					// check if the word is in the dictionary. If missing, omit the phrase, and log
+					vector<string> splitString = Split(it->first);
+					vector<string>::iterator v_It;
+
+					bool skip = false;
+					for (v_It = splitString.begin(); v_It != splitString.end(); ++v_It) {
+						if (dictionary.find(*v_It) == dictionary.end()) {
+							skip = true;
+						}
+					}
+
+					if (skip)
+					{
+						std::string Strtxt = "The phrase '" + it->first + "' can not be added, as it contains words that are not in the dictionary.";
+						const char* txt = Strtxt.c_str();
+						// "' contains words that do not exist in the dictionary. Ignoring phrase.";
+						FString msg = FString(UTF8_TO_TCHAR(txt));
+						UE_LOG(SpeechRecognitionPlugin, Log, TEXT("SKIPPED PHRASE: %s "), *msg);
+						continue;
+					}
+
+					// keyword
+					char* str;
+					str = (char *)malloc(it->first.size() + 1);
+					memcpy(str, it->first.c_str(), it->first.size() + 1);
+					phrases[i] = str;
+
+					//tollerence
+					int32 tollerenceInt = (int32)logmath_log(ps_get_logmath(ps), atof(it->second)) >> SENSCR_SHIFT;
+					tollerences[i] = tollerenceInt;
+					i++;
+				}
+
+				int phraseCnt = i;
+				const char** const_copy = (const char**)phrases;
+				ps_set_keyphrase(ps, "keyphrase_search", const_copy, tollerences, phraseCnt);
+				ps_set_search(ps, "keyphrase_search");
+			}
+
+			// attempt to open the default recording device
+			if ((ad = ad_open_dev(cmd_ln_str_r(config, "-adcdev"),
+				(int)cmd_ln_float32_r(config,
+					"-samprate"))) == NULL) {
+				ClientMessage(FString(TEXT("Failed to open audio device")));
+				return 2;
+			}
+
+			if (ad_start_rec(ad) < 0) {
+				ClientMessage(FString(TEXT("Failed to start recording")));
+				return 3;
+			}
+
+			if (ps_start_utt(ps) < 0) {
+				ClientMessage(FString(TEXT("Failed to start utterance")));
+				return 4;
+			}
+
+			initRequired = false;
+			initComplete = true;
+			utt_started = 0;
+		}else {
+			if(initComplete == false) {
+				FPlatformProcess::Sleep(0.01f);
+				if (StopTaskCounter.GetValue() == 1) {
+					return 0;
+				}
+				continue;
+			}
+		}
+		
 		if ((k = ad_read(ad, adbuf, 1024)) < 0)
 			ClientMessage(FString(TEXT("Failed to read audio")));
 
@@ -244,6 +299,7 @@ uint32 FSpeechRecognitionWorker::Run() {
 		prev_in_speech = in_speech;
 		in_speech = ps_get_in_speech(ps);
 
+		// clear detection for when speech starts and stops
 		if (in_speech != prev_in_speech) {
 			if (in_speech) {
 				Manager->StartedSpeaking_method();
@@ -255,36 +311,90 @@ uint32 FSpeechRecognitionWorker::Run() {
 
 		if (in_speech && !utt_started) {
 			utt_started = 1;
+			ClientMessage(FString(TEXT("Listening")));
 		}
-		if (!in_speech && utt_started) {
 
-			// obtain a count of the number of frames, and the hypothesis phrase spoken
-			int32 frameCount = ps_get_n_frames(ps);
-			int32 score;
-			const char* hyp = ps_get_hyp(ps, &score);
+		// change how we process incoming sound based on if live recognition is enabled or not
+		if (Manager->GetLiveRecognition()) {
+			// make sure we don't check too often for complete phrases
+			elapsed_time_ms = (clock() - prev_time) / (CLOCKS_PER_SEC / 1000);
+			if (elapsed_time_ms >= Manager->GetDelayTime() * 1000) {
+				prev_time = clock();
+				// get the hyp for anything recorded so far
+				const char* hyp = ps_get_hyp(ps, NULL);
 
-			// re-loop, if there is no hypothesis
-			if (hyp == NULL)
-				continue;
+				// if speech so far contains any matching phrases, process them and start over
+				if (hyp != NULL) {
+					ps_end_utt(ps);
 
-			// log the phrase/phrases that have been spoken, and trigger WordSpoken method
-			FString phrases = FString(UTF8_TO_TCHAR(hyp));
-			ClientMessage(phrases);
-			UE_LOG(SpeechRecognitionPlugin, Log, TEXT("Phrases: %s "), *phrases);
-			Manager->WordSpoken_method(phrases);
+					ProcessIncomingSound();
 
-			// end utterence, and start listening for a new phrase
-			ps_end_utt(ps);
-			if (ps_start_utt(ps) < 0)
-				ClientMessage(FString(TEXT("Failed to start")));
-			utt_started = 0;
-			UE_LOG(SpeechRecognitionPlugin, Log, TEXT("Listening..."));
+					if (ps_start_utt(ps) < 0)
+						ClientMessage(FString(TEXT("Failed to start")));
+					utt_started = 0;
+				}
+			}
+		}
+		else {
+			// when speaking has stopped
+			if (!in_speech && utt_started) {
+				ps_end_utt(ps);
+				// get the hyp for all recorded speech
+				const char* hyp = ps_get_hyp(ps, NULL);
 
+				// if recorded speech contains matching phrases, process them
+				if (hyp != NULL) {
+					ProcessIncomingSound();
+				}
+
+				// start listening for a new phrase
+				if (ps_start_utt(ps) < 0)
+					ClientMessage(FString(TEXT("Failed to start")));
+				utt_started = 0;
+			}		
+		}
+	}
+	ad_close(ad);
+	ps_free(ps);
+	cmd_ln_free_r(config);
+
+	return 0;
+}
+
+void FSpeechRecognitionWorker::ProcessIncomingSound() {
+	int frame_rate = cmd_ln_int32_r(config, "-frate");
+	ps_seg_t *iter = ps_seg_iter(ps);
+
+	map<float, FString> orderedPhrases;
+	map<float, FString>::iterator it;
+
+	while (iter != NULL) {
+		int32 sf, ef;
+		ps_seg_frames(iter, &sf, &ef);
+		FString word = FString(ps_seg_word(iter));
+		float startTime = ((float)sf / frame_rate);
+		float endTime = ((float)ef / frame_rate);
+		UE_LOG(SpeechRecognitionPlugin, Log, TEXT("Word: %s Start Time: %.3f End Time %.3f"), *word, startTime,
+			endTime);
+		iter = ps_seg_next(iter);
+		orderedPhrases.insert(pair<float, FString>(startTime, word));
+	}
+
+	TArray<FString> phrases;
+	for (it = orderedPhrases.begin(); it != orderedPhrases.end(); ++it) {
+		FString word = it->second;
+		if (!word.Equals(TEXT("<sil>"), ESearchCase::IgnoreCase))
+		{
+			UE_LOG(SpeechRecognitionPlugin, Log, TEXT("Phrase: %s "), *word);
+			phrases.Add(word);
 		}
 	}
 
-	ad_close(ad);
-	return 0;
+	FRecognisedPhrases recogPhrases;
+	recogPhrases.phrases = phrases;
+	Manager->WordsSpoken_method(recogPhrases);
+
+	return;
 }
 
 void FSpeechRecognitionWorker::Stop() {
@@ -295,9 +405,8 @@ bool FSpeechRecognitionWorker::StartThread(ASpeechRecognitionActor* manager) {
 	Manager = manager;
 	int32 threadIdx = ISpeechRecognition::Get().GetInstanceCounter();
 	FString threadName = FString("FSpeechRecognitionWorker:") + FString::FromInt(threadIdx);
-	initSuccess = true;
 	Thread = FRunnableThread::Create(this, *threadName, 0U, TPri_Highest);
-	return initSuccess;
+	return true;
 }
 
 void FSpeechRecognitionWorker::ClientMessage(FString text) {

--- a/Plugins/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognition.h
+++ b/Plugins/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognition.h
@@ -1,9 +1,83 @@
 #pragma once
 
 #include "Engine.h"
-#include "SpeechRecognitionActor.h"
-#include "SpeechRecognitionWorker.h"
 #include "ISpeechRecognition.h"
+#include "SpeechRecognition.generated.h"
+
+//Common structures and enumerations
+
+USTRUCT(BlueprintType)
+struct FRecognisedPhrases
+{
+	GENERATED_USTRUCT_BODY()
+
+		UPROPERTY(BlueprintReadWrite)
+		TArray<FString> phrases;
+
+	// default constructor
+	FRecognisedPhrases() {
+	}
+};
+
+
+UENUM(BlueprintType)
+enum class ESpeechRecognitionMode : uint8
+{
+	VE_KEYWORD 	UMETA(DisplayName = "Keyword Spotting"),
+	VE_GRAMMAR  UMETA(DisplayName = "Grammar"),
+	VE_PHONETIC	UMETA(DisplayName = "Phonetic")
+};
+
+UENUM(BlueprintType)
+enum class ESpeechRecognitionLanguage : uint8
+{
+	VE_English 	UMETA(DisplayName = "English"),
+	VE_Chinese  UMETA(DisplayName = "Chinese"),
+	VE_French	UMETA(DisplayName = "French")
+};
+
+UENUM(BlueprintType)
+enum class EPhraseRecognitionTolerance : uint8
+{
+	VE_1 	UMETA(DisplayName = "V1"),
+	VE_2 	UMETA(DisplayName = "V2"),
+	VE_3 	UMETA(DisplayName = "V3"),
+	VE_4 	UMETA(DisplayName = "V4"),
+	VE_5 	UMETA(DisplayName = "V5"),
+	VE_6 	UMETA(DisplayName = "V6"),
+	VE_7 	UMETA(DisplayName = "V7"),
+	VE_8 	UMETA(DisplayName = "V8"),
+	VE_9 	UMETA(DisplayName = "V9"),
+	VE_10 	UMETA(DisplayName = "V10")
+};
+
+USTRUCT(BlueprintType)
+struct FRecognitionPhrase
+{
+	GENERATED_USTRUCT_BODY()
+
+		UPROPERTY(BlueprintReadWrite)
+		FString phrase;
+
+	UPROPERTY(BlueprintReadWrite)
+		EPhraseRecognitionTolerance tolerance;
+
+	// default constructor
+	FRecognitionPhrase() {
+	}
+
+	// if you wish to only provide a phrase
+	FRecognitionPhrase(FString keyword) {
+		this->phrase = phrase;
+		tolerance = EPhraseRecognitionTolerance::VE_5;
+	}
+
+	// if you wish to specify both a phrase, and a tolerance setting
+	FRecognitionPhrase(FString phrase, EPhraseRecognitionTolerance tolerance) {
+		this->phrase = phrase;
+		this->tolerance = tolerance;
+	}
+};
 
 class FSpeechRecognition :public ISpeechRecognition
 {

--- a/Plugins/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognitionActor.h
+++ b/Plugins/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognitionActor.h
@@ -2,13 +2,14 @@
 #pragma once
 
 #include "SpeechRecognitionWorker.h"
+#include "SpeechRecognition.h"
 #include "TaskGraphInterfaces.h"
 #include "SpeechRecognitionActor.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FStartedSpeakingSignature);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FStoppedSpeakingSignature);
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWordsSpokenSignature, FString, Text);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWordsSpokenSignature, FRecognisedPhrases, phrases);
 
 UCLASS(BlueprintType, Blueprintable)
 class SPEECHRECOGNITION_API ASpeechRecognitionActor : public AActor
@@ -20,25 +21,48 @@ private:
 	int32 instanceCtr;
 	
 	FSpeechRecognitionWorker* listenerThread;
+	bool live_recognition;
+	float delay_time;
 
-	static void WordSpoken_trigger(FWordsSpokenSignature delegate_method, FString text);
+	static void WordsSpoken_trigger(FWordsSpokenSignature delegate_method, FRecognisedPhrases text);
 	static void StartedSpeaking_trigger(FStartedSpeakingSignature delegate_method);
 	static void StoppedSpeaking_trigger(FStoppedSpeakingSignature delegate_method);
 
 public:
+	/** Live recognition will process words as they are heard. 
+Otherwise speech will be processed when speaking ends. */
+	UFUNCTION(BlueprintCallable, Category = "Audio")
+	void SetLiveRecognition(bool live_recognition);
+
+	bool GetLiveRecognition();
+	float GetDelayTime();
+
+	//Methods to switch recognition modes
+	UFUNCTION(BlueprintCallable, Category = "Audio", meta = (DisplayName = "Enable Keyword Mode", Keywords = "Speech Recognition Mode"))
+	bool EnableKeywordMode(TArray<FRecognitionPhrase> wordList);
+
+	UFUNCTION(BlueprintCallable, Category = "Audio", meta = (DisplayName = "Enable Grammar Mode", Keywords = "Speech Recognition Mode"))
+	bool EnableGrammarMode(FString grammarName);
+
+	UFUNCTION(BlueprintCallable, Category = "Audio", meta = (DisplayName = "Enable Phonetic Mode", Keywords = "Speech Recognition Mode"))
+	bool EnablePhoneticMode();
 
 	// Basic functions 
+	/** Live recognition will process words as they are heard.
+Otherwise speech will be processed when speaking ends.
+Delay Time is only used for Live Recognition.*/
 	UFUNCTION(BlueprintCallable, Category = "Audio", meta = (DisplayName = "Init", Keywords = "Speech Recognition Init"))
-	bool Init(ESpeechRecognitionLanguage language, TArray<FRecognitionPhrase> wordList);
+	bool Init(ESpeechRecognitionLanguage language, bool live_recognition, float delay_time = 0.1);
 
 	UFUNCTION(BlueprintCallable, Category = "Audio", meta = (DisplayName = "Shutdown", Keywords = "Speech Recognition Shutdown"))
 	bool Shutdown();
 
+	// Callback events
 	UFUNCTION()
-	void WordSpoken_method(FString text);
+	void WordsSpoken_method(FRecognisedPhrases phrases);
 
 	UPROPERTY(BlueprintAssignable, Category = "Audio")
-	FWordsSpokenSignature OnWordSpoken;
+	FWordsSpokenSignature OnWordsSpoken;
 
 	UFUNCTION()
 	void StartedSpeaking_method();
@@ -51,4 +75,5 @@ public:
 
 	UPROPERTY(BlueprintAssignable, Category = "Audio")
 	FStoppedSpeakingSignature OnStoppedSpeaking;
+	
 };

--- a/Plugins/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognitionWorker.h
+++ b/Plugins/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognitionWorker.h
@@ -12,61 +12,10 @@
 #include <fstream>
 #include <iostream>
 #include <cstdio>
+#include <ctime>
 #include <vector>
 #include <utility>
-#include "SpeechRecognitionWorker.generated.h"
 
-
-UENUM(BlueprintType)
-enum class ESpeechRecognitionLanguage : uint8
-{
-	VE_English 	UMETA(DisplayName = "English"),
-	VE_Chinese  UMETA(DisplayName = "Chinese"),
-	VE_French	UMETA(DisplayName = "French")
-};
-
-UENUM(BlueprintType)
-enum class EPhraseRecognitionTolerance : uint8
-{
-	VE_1 	UMETA(DisplayName = "V1"),
-	VE_2 	UMETA(DisplayName = "V2"),
-	VE_3 	UMETA(DisplayName = "V3"),
-	VE_4 	UMETA(DisplayName = "V4"),
-	VE_5 	UMETA(DisplayName = "V5"),
-	VE_6 	UMETA(DisplayName = "V6"),
-	VE_7 	UMETA(DisplayName = "V7"),
-	VE_8 	UMETA(DisplayName = "V8"),
-	VE_9 	UMETA(DisplayName = "V9"),
-	VE_10 	UMETA(DisplayName = "V10")
-};
-
-USTRUCT(BlueprintType)
-struct FRecognitionPhrase
-{
-	GENERATED_USTRUCT_BODY()
-
-	UPROPERTY(BlueprintReadWrite)
-	FString phrase;
-
-	UPROPERTY(BlueprintReadWrite)
-	EPhraseRecognitionTolerance tolerance;
-
-	// default constructor
-	FRecognitionPhrase() {
-	}
-
-	// if you wish to only provide a phrase
-	FRecognitionPhrase(FString keyword){
-		this->phrase = phrase;
-		tolerance = EPhraseRecognitionTolerance::VE_5;
-	}
-
-	// if you wish to specify both a phrase, and a tolerance setting
-	FRecognitionPhrase(FString phrase, EPhraseRecognitionTolerance tolerance) {
-		this->phrase = phrase;
-		this->tolerance = tolerance;
-	}
-};
 
 //General Log
 DECLARE_LOG_CATEGORY_EXTERN(SpeechRecognitionPlugin, Log, All);
@@ -82,14 +31,17 @@ class FSpeechRecognitionWorker :public FRunnable
 
 private:
 	// Sphinx
-	ps_decoder_t *ps;
-	cmd_ln_t *config;
+	ps_decoder_t *ps = NULL;
+	cmd_ln_t *config = NULL;
 	ad_rec_t *ad;
 	int16 adbuf[2048];
 	uint8 utt_started, in_speech;
 	int32 k;
-	bool initSuccess;
-	bool wordsAdded;
+	bool initRequired = false;
+	bool wordsAdded = false;
+
+	//Speech detection mode
+	ESpeechRecognitionMode detectionMode;
 
 	//Thread
 	FRunnableThread* Thread;
@@ -103,8 +55,13 @@ private:
 	//Language
 	char* langStr = NULL;
 
-	//Path to the content folder
+	//Paths
 	std::string contentPath_str;
+	std::string logPath;
+	std::string modelPath;
+	std::string languageModel;
+	std::string dictionaryPath;
+
 
 	//Stores the recognition keywords, along with their tollerences
 	std::map <string , char*> keywords;
@@ -115,22 +72,33 @@ private:
 	//Splits a string by whitespace
 	std::vector<std::string> FSpeechRecognitionWorker::Split(std::string s);
 
+	//Create default Pocketsphinx constructor
+	void InitConfig();
+
+	//Add phrases to keyword match list (only required for Keyword matching)
+	void AddWords(TArray<FRecognitionPhrase> dictionaryList);
+
+	void ProcessIncomingSound();
+
 public:
 	FSpeechRecognitionWorker();
 	virtual ~FSpeechRecognitionWorker();
 
 	//FRunnable interface
-	virtual bool Init();
 	virtual void Stop();
 	virtual uint32 Run();
 
-	void AddWords(TArray<FRecognitionPhrase> dictionaryList);
+	//Methods to switch recognition modes
+	bool EnableKeywordMode(TArray<FRecognitionPhrase> wordList);
+	bool EnableGrammarMode(FString grammarName);
+	bool EnablePhoneticMode();
+
 	void SetLanguage(ESpeechRecognitionLanguage language);
 	bool StartThread(ASpeechRecognitionActor* manager);
-
-	static void ClientMessage(FString txt);
-
 	void ShutDown();
+
+	//Print debug text
+	static void ClientMessage(FString txt);
 
 };
 


### PR DESCRIPTION
Modified plugin to have the option for 'live recognition' this allows the user to specify how often they would like the plugin to check for any words that have been spoken so far. This improves performance in settings with high background noise, but does limit the length of chained phrases, previous implementation (listen until no sound is heard) is still available by simply not using the live recognition